### PR TITLE
Change logic for detecting tuplet ends

### DIFF
--- a/src/Utilities.mss
+++ b/src/Utilities.mss
@@ -235,14 +235,17 @@ function TupletsEqual (t, t2) {
 
 function IsLastNoteInTuplet (bobj) {
     //$module(Utilities.mss)
-    if (bobj.ParentTupletIfAny = null or bobj.GraceNote = True)
+    next_obj = bobj.NextItem(bobj.VoiceNumber, 'NoteRest');
+
+    if (next_obj = null)
     {
-        return false;
+        return true;
     }
 
     tuplet = bobj.ParentTupletIfAny;
+    next_obj_tuplet = next_obj.ParentTupletIfAny;
 
-    if (bobj.PositionInTuplet >= tuplet.Duration)
+    if (next_obj_tuplet = null or tuplet.Position != next_obj_tuplet.Position)
     {
         return true;
     }


### PR DESCRIPTION
I don't really understand `tuplet.Duration` as it has pretty odd values, but it obviously is the cause of the duplicate tuplet issue. I tried different logic which seems to work, but this pull request needs some pair of experienced eyes to check whether it's actually sound.

Fixes #45