### PR TITLE
Add @metcon="false" to measures not conforming to time signature

### DIFF
--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -301,6 +301,15 @@ function GenerateMeasure (num) {
     // since so much metadata about the staff and other context
     // is available on the bar that should now be on the measure, go through the bars
     // and try to extract it.
+    
+    systf = score.SystemStaff;
+    currTimeS = systf.CurrentTimeSignature(num);
+    sysBar = systf[num];
+    
+    if (sysBar.Length != (currTimeS.Numerator * 1024 / currTimeS.Denominator))
+    {
+        libmei.AddAttribute(m, 'metcon', 'false');
+    }
 
     for i = 1 to staves.Length + 1
     {


### PR DESCRIPTION
This is to make it easier for consuming applications to cope with pickup bars and the like.

I'm not sure what's the best way to access the current time signature - I passed it as argument, but if that's undesired, please let me know.

In contrast to the `ExternalBarNumberString` check, I put this outside the loop through all staffs.