### PR TITLE
Avoid occasional error "ProcessSymbol:12:Field bar not found"

### DIFF
--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -638,7 +638,7 @@ function GenerateLayers (staffnum, measurenum) {
 
     for each SymbolItem sobj in bar
     {
-        ProcessSymbol(sobj);
+        ProcessSymbol(sobj, bar);
     }
 
     return layers;

--- a/src/ExportProcessors.mss
+++ b/src/ExportProcessors.mss
@@ -503,7 +503,7 @@ function ProcessTremolo (bobj) {
     
 } //$end
 
-function ProcessSymbol (sobj) {
+function ProcessSymbol (sobj, bar) {
     //$module(ExportProcessors.mss)
     Log('symbol index: ' & sobj.Index & ' name: ' & sobj.Name);
     Log(sobj.VoiceNumber);


### PR DESCRIPTION
I occasionally get the error `ProcessSymbol:12:Field bar not found` - not sure when and why exactly. But this seems to fix it.

To avoid the additional parameter, we could also use `Self._property:CurrentBar`. Would that be preferable?