### PR TITLE
Fix crahs for empty measure with clef

### DIFF
--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -436,6 +436,7 @@ function GenerateLayers (staffnum, measurenum) {
     score = Self._property:ActiveScore;
     this_staff = score.NthStaff(staffnum);
     bar = this_staff[measurenum];
+    l = null;
 
     for each bobj in bar
     {
@@ -454,7 +455,7 @@ function GenerateLayers (staffnum, measurenum) {
         }
         else
         {
-            if (voicenumber != 0)
+            if (voicenumber != 0 or (l = null and bobj.Type = 'Clef'))
             {
                 l = libmei.Layer();
                 layers.Push(l._id);
@@ -466,6 +467,19 @@ function GenerateLayers (staffnum, measurenum) {
 
                 layerdict[voicenumber] = l;
                 libmei.AddAttribute(l, 'n', voicenumber);
+
+                if (bobj.Type = 'Clef' and bobj.Position > 0)
+                {
+                    /* 
+                       Clefs on voice 0 without preceding content are most likely the only
+                       element in a staff cell that is otherwise empty (except for cross-
+                       staff content). Therefore we add a <space> element before it.
+                    */
+                    space = libmei.Space();
+                    meidur = ConvertDuration(bobj.Position);
+                    libmei.AddAttribute(space, 'dur', meidur[0]);
+                    libmei.AddChild(l, space);
+                }
             }
         }
 


### PR DESCRIPTION
The attached test file has cross staff notation where one staff has no content at all, except for a clef at the end of the measure. This currently crashes sibmei as it tries to attach the clef to the last existing layer, but no layer has been created yet.

This patch creates a layer for clefs that occur before anything else in the measure. If the clef is not at position 0, it also creates a `<space>` element to fill the empty room in the layer.

[empty-measure-with-clef.sib.zip](https://github.com/music-encoding/sibmei/files/752421/empty-measure-with-clef.sib.zip)
