### PR TITLE
Support fermatas on BarRests

### DIFF
--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -779,43 +779,15 @@ function GenerateNoteRest (bobj, layer) {
         libmei.AddAttribute(nr, 'grace', 'acc');
     }
 
-    if (bobj.GetArticulation(PauseArtic))
+    if (bobj.GetArticulation(PauseArtic) or bobj.GetArticulation(TriPauseArtic) or bobj.GetArticulation(SquarePauseArtic))
     {
-        fermata = libmei.Fermata();
-        libmei.AddAttribute(fermata, 'form', 'norm');
-        libmei.AddAttribute(fermata, 'shape', 'curved');
-        libmei.AddAttribute(fermata, 'startid', '#' & nr._id);
-        libmei.AddAttribute(fermata, 'layer', bobj.VoiceNumber);
-        libmei.AddAttribute(fermata, 'staff', bobj.ParentBar.ParentStaff.StaffNum);
-
-        mlines = Self._property:MeasureObjects;
-        mlines.Push(fermata._id);
-    }
-
-    if (bobj.GetArticulation(TriPauseArtic))
-    {
-        fermata = libmei.Fermata();
-        libmei.AddAttribute(fermata, 'form', 'norm');
-        libmei.AddAttribute(fermata, 'shape', 'angular');
-        libmei.AddAttribute(fermata, 'startid', '#' & nr._id);
-        libmei.AddAttribute(fermata, 'layer', bobj.VoiceNumber);
-        libmei.AddAttribute(fermata, 'staff', bobj.ParentBar.ParentStaff.StaffNum);
-
-        mlines = Self._property:MeasureObjects;
-        mlines.Push(fermata._id);
-    }
-
-    if (bobj.GetArticulation(SquarePauseArtic))
-    {
-        fermata = libmei.Fermata();
-        libmei.AddAttribute(fermata, 'form', 'norm');
-        libmei.AddAttribute(fermata, 'shape', 'square');
-        libmei.AddAttribute(fermata, 'startid', '#' & nr._id);
-        libmei.AddAttribute(fermata, 'layer', bobj.VoiceNumber);
-        libmei.AddAttribute(fermata, 'staff', bobj.ParentBar.ParentStaff.StaffNum);
-
-        mlines = Self._property:MeasureObjects;
-        mlines.Push(fermata._id);
+        fermata = GenerateFermata(bobj);
+        if (fermata != null)
+        {
+            libmei.AddAttribute(fermata, 'startid', '#' & nr._id);
+            measureObjs = Self._property:MeasureObjects;
+            measureObjs.Push(fermata._id);
+        }
     }
 
     if (bobj.GetArticulation(StaccatoArtic))
@@ -1176,6 +1148,14 @@ function GenerateBarRest (bobj) {
             return null;
         }
     }
+    
+    fermata = GenerateFermata(bobj);
+    if (fermata != null)
+    {
+        libmei.AddAttribute(fermata, 'startid', '#' & obj._id);
+        measureObjs = Self._property:MeasureObjects;
+        measureObjs.Push(fermata._id);
+    }
 
     if (bobj.Hidden = true)
     {
@@ -1441,6 +1421,67 @@ function GenerateTrill (bobj) {
     trill = AddBarObjectInfoToElement(bobj, trill);
 
     return trill;
+}  //$end
+
+
+function GenerateFermata (bobj) {
+    //$module(ExportGenerators.mss)
+    /* Note rests can have multiple fermatas in Sibelius, 
+        but this is currently not supported.
+        Also, fermatas added as symbols are not yet handled.
+    */
+    shape = null;
+
+    switch (bobj.Type)
+    {
+        case('NoteRest')
+        {
+            if (bobj.GetArticulation(PauseArtic))
+            {
+                shape = 'curved';
+            }
+            if (bobj.GetArticulation(TriPauseArtic))
+            {
+                shape = 'angular';
+            }
+            if (bobj.GetArticulation(SquarePauseArtic))
+            {
+                shape = 'square';
+            }
+        }
+        case('BarRest')
+        {
+            switch (bobj.PauseType)
+            {
+                case(PauseTypeRound)
+                {
+                    shape = 'curved';
+                }
+                case(PauseTypeTriangular)
+                {
+                    shape = 'angular';
+                }
+                case(PauseTypeSquare)
+                {
+                    shape = 'square';
+                }
+            }
+        }
+    }
+    
+    if (shape = null)
+    {
+        return null;
+    }
+        
+    fermata = libmei.Fermata();
+    
+    libmei.AddAttribute(fermata, 'form', 'norm');
+    libmei.AddAttribute(fermata, 'shape', shape);
+    
+    fermata = AddBarObjectInfoToElement(bobj, fermata);
+    
+    return fermata;
 }  //$end
 
 function GenerateChordSymbol (bobj) {

--- a/src/Utilities.mss
+++ b/src/Utilities.mss
@@ -140,7 +140,7 @@ function GetNoteObjectAtPosition (bobj) {
 function AddBarObjectInfoToElement (bobj, element) {
     //$module(Utilities.mss)
     /*
-        adds timing and position info (startids, endids, tstamps, etc.) to an element
+        adds timing and position info (tstamps, etc.) to an element.
         This info is mostly derived from the base BarObject class.
     */
     voicenum = bobj.VoiceNumber;


### PR DESCRIPTION
I re-used the fermata generation code for `BarRest`s. To avoid identical copy&paste code in 6 places, I created `GenerateFermata(bobj, anchor, shape)`.

If there's problem with the multiple arguments, please let me know.  What's the reason for preferring single-argument functions? Are there ManuScript specific problems with more than one argument or is there a general coding philosophy behind this?

[fermatas.sib.zip](https://github.com/music-encoding/sibmei/files/752574/fermatas.sib.zip)
