### PR TITLE
Support nested tuplets with stackarray

### DIFF
--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -515,20 +515,6 @@ function GenerateLayers (staffnum, measurenum) {
                                 if (tuplet.name != 'tupletSpan')
                                 {
                                     ShiftTupletToTupletSpan(tuplet, l);
-                                    tsid = l._property:ActiveTupletId;
-                                    tsobj = libmei.getElementById(tsid);
-
-                                    if (tsobj._parent = null and tsobj._property:AddedToMeasure = False)
-                                    {
-                                        /*
-                                            The measure lines get added to the measure object
-                                            so pretend this tuplet span object is a line
-                                            and queue it for addition to the measure.
-                                        */
-                                        tsobj._property:AddedToMeasure = True;
-                                        mobj = tsobj;
-                                    }
-
                                 }
                             }
                             else
@@ -1339,6 +1325,46 @@ function GenerateStaffGroups (score) {
         
     }
     return parentstgrp;
+}  //$end
+
+function GenerateTuplet(tupletObj) {
+    //$module(ExportGenerators.mss)
+    tuplet = libmei.Tuplet();
+  
+    libmei.AddAttribute(tuplet, 'num', tupletObj.Left);
+    libmei.AddAttribute(tuplet, 'numbase', tupletObj.Right);
+
+    tupletStyle = tupletObj.Style;
+
+    switch (tupletStyle)
+    {
+        case(TupletNoNumber)
+        {
+            libmei.AddAttribute(tuplet, 'dur.visible', 'false');
+        }
+        case(TupletLeft)
+        {
+            libmei.AddAttribute(tuplet, 'num.format', 'count');
+        }
+        case(TupletLeftRight)
+        {
+            libmei.AddAttribute(tuplet, 'num.format', 'ratio');
+        }
+    }
+
+    tupletBracket = tupletObj.Bracket;
+
+    switch(tupletBracket)
+    {
+        case(TupletBracketOff)
+        {
+            libmei.AddAttribute(tuplet, 'bracket.visible', 'false');
+        }
+    }
+    
+    tuplet._property:SibTuplet = tupletObj;
+
+    return tuplet;
 }  //$end
 
 function GenerateLine (bobj) {


### PR DESCRIPTION
This is a rewrite of `ProcessTuplet()` and related code to support nested tuplets. I've implemented two variants for keeping track of and comparing tuplet nesting between notes. One uses arrays (this pull request), the other one (#69) a linked list. Which method is preferable?

[nested-tuplets.sib.zip](https://github.com/music-encoding/sibmei/files/784838/nested-tuplets.sib.zip)
