### PR TITLE
Support nested tuplets with linked list

### DIFF
--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -515,20 +515,6 @@ function GenerateLayers (staffnum, measurenum) {
                                 if (tuplet.name != 'tupletSpan')
                                 {
                                     ShiftTupletToTupletSpan(tuplet, l);
-                                    tsid = l._property:ActiveTupletId;
-                                    tsobj = libmei.getElementById(tsid);
-
-                                    if (tsobj._parent = null and tsobj._property:AddedToMeasure = False)
-                                    {
-                                        /*
-                                            The measure lines get added to the measure object
-                                            so pretend this tuplet span object is a line
-                                            and queue it for addition to the measure.
-                                        */
-                                        tsobj._property:AddedToMeasure = True;
-                                        mobj = tsobj;
-                                    }
-
                                 }
                             }
                             else
@@ -1339,6 +1325,46 @@ function GenerateStaffGroups (score) {
         
     }
     return parentstgrp;
+}  //$end
+
+function GenerateTuplet(tupletObj) {
+    //$module(ExportGenerators.mss)
+    tuplet = libmei.Tuplet();
+  
+    libmei.AddAttribute(tuplet, 'num', tupletObj.Left);
+    libmei.AddAttribute(tuplet, 'numbase', tupletObj.Right);
+
+    tupletStyle = tupletObj.Style;
+
+    switch (tupletStyle)
+    {
+        case(TupletNoNumber)
+        {
+            libmei.AddAttribute(tuplet, 'dur.visible', 'false');
+        }
+        case(TupletLeft)
+        {
+            libmei.AddAttribute(tuplet, 'num.format', 'count');
+        }
+        case(TupletLeftRight)
+        {
+            libmei.AddAttribute(tuplet, 'num.format', 'ratio');
+        }
+    }
+
+    tupletBracket = tupletObj.Bracket;
+
+    switch(tupletBracket)
+    {
+        case(TupletBracketOff)
+        {
+            libmei.AddAttribute(tuplet, 'bracket.visible', 'false');
+        }
+    }
+    
+    tuplet._property:SibTuplet = tupletObj;
+
+    return tuplet;
 }  //$end
 
 function GenerateLine (bobj) {

--- a/src/ExportProcessors.mss
+++ b/src/ExportProcessors.mss
@@ -92,83 +92,81 @@ function ProcessBeam (bobj, layer) {
     return ret;
 }  //$end
 
-function ProcessTuplet (bobj, meielement, layer) {
+function ProcessTuplet (noteRest, meielement, layer) {
     //$module(ExportProcessors.mss)
-    if (bobj.ParentTupletIfAny = null)
+    if (noteRest.ParentTupletIfAny = null)
     {
         return null;
     }
-
-    if (layer._property:ActiveTupletId = null)
+    
+    /*
+       We encode inner tuplets of nested tuplet structures as <tupletSpan>s.
+       Therefore we always return the outermost MEI tuplet for content to be added.
+       Still, we need to keep track of the inner tuplets to assign the @endid.
+       layer._property:ActiveMeiTuplet always points to the innermost tuplet.
+    */
+    
+    activeMeiTuplet = layer._property:ActiveMeiTuplet;
+    
+    tupletIsContinued = (activeMeiTuplet != null) and TupletsEqual(noteRest.ParentTupletIfAny, activeMeiTuplet._property:SibTuplet);
+    
+    if (not(tupletIsContinued))
     {
-        tupletObject = bobj.ParentTupletIfAny;
-
-        tuplet = libmei.Tuplet();
-
-        layer._property:ActiveTupletObject = tupletObject;
-        layer._property:ActiveTupletId = tuplet._id;
-
-        if (libmei.GetName(meielement) = 'beam')
+        // New tuplets need to be added
+        meiTupletDepth = GetMeiTupletDepth(layer);
+        sibTupletDepth = GetSibTupletDepth(noteRest);
+        previousNewMeiTuplet = null;
+        sibTuplet = noteRest.ParentTupletIfAny;
+      
+        for i = meiTupletDepth to sibTupletDepth
         {
-            // get the first child
-            startid = meielement.children[0];
+            newMeiTuplet = GenerateTuplet(sibTuplet);
+            if ((meiTupletDepth > 0) or (i < (sibTupletDepth - 1)))
+            {
+                // We have an inner tuplet that we encode as <tupletSpan> to not
+                // over-complicate the logic requied in GenerateLayers().
+                newMeiTuplet = ShiftTupletToTupletSpan(newMeiTuplet, layer);
+            }
+            if (i = meiTupletDepth)
+            {
+                // The innermost tuplet must become the new active tuplet.
+                layer._property:ActiveMeiTuplet = newMeiTuplet;
+            }
+            libmei.AddAttribute(newMeiTuplet, 'startid', '#' & meielement._id);
+            // We basically create a linked list of tuplets. While we step through the Sib tuplets
+            // from the inside out and create the innermost tuplet first, we need the tuplets to
+            if (previousNewMeiTuplet != null)
+            {
+                previousNewMeiTuplet._property:ParentTuplet = newMeiTuplet;
+            }
+            newMeiTuplet._property:SibTuplet = sibTuplet;
+            previousNewMeiTuplet = newMeiTuplet;
+            sibTuplet = sibTuplet.ParentTupletIfAny;
         }
-        else
+        if (previousNewMeiTuplet != null)
         {
-            startid = meielement._id;
+            previousNewMeiTuplet._property:ParentTuplet = activeMeiTuplet;
         }
-
-        libmei.AddAttribute(tuplet, 'startid', '#' & startid);
-        libmei.AddAttribute(tuplet, 'num', tupletObject.Left);
-        libmei.AddAttribute(tuplet, 'numbase', tupletObject.Right);
-
-        tupletStyle = tupletObject.Style;
-
-        switch (tupletStyle)
-        {
-            case(TupletNoNumber)
-            {
-                libmei.AddAttribute(tuplet, 'dur.visible', 'false');
-            }
-            case(TupletLeft)
-            {
-                libmei.AddAttribute(tuplet, 'num.format', 'count');
-            }
-            case(TupletLeftRight)
-            {
-                libmei.AddAttribute(tuplet, 'num.format', 'ratio');
-            }
-        }
-
-        tupletBracket = tupletObject.Bracket;
-
-        switch(tupletBracket)
-        {
-            case(TupletBracketOff)
-            {
-                libmei.AddAttribute(tuplet, 'bracket.visible', 'false');
-            }
-        }
-
-        return tuplet;
     }
-    else
+
+    innermostMeiTuplet = layer._property:ActiveMeiTuplet;
+    outermostMeiTuplet = layer._property:ActiveMeiTuplet;
+
+    for i = 0 to CountTupletsEndingAtNoteRest(noteRest)
     {
-        tid = layer._property:ActiveTupletId;
-        t = libmei.getElementById(tid);
-
-        if (IsLastNoteInTuplet(bobj))
-        {
-            libmei.AddAttribute(t, 'endid', '#' & meielement._id);
-            layer._property:ActiveTupletObject = null;
-            layer._property:ActiveTupletId = null;
-        }
-
-        return t;
+        libmei.AddAttribute(innermostMeiTuplet, 'endid', '#' & meielement._id);
+        innermostMeiTuplet = innermostMeiTuplet._property:ParentTuplet;
     }
+    layer._property:ActiveMeiTuplet = innermostMeiTuplet;
+    
+    while (outermostMeiTuplet._property:ParentTuplet)
+    {
+        outermostMeiTuplet = outermostMeiTuplet._property:ParentTuplet;
+    }
+    return outermostMeiTuplet;
 }  //$end
 
-function ShiftTupletToTupletSpan (tuplet, layer) {
+function ShiftTupletToTupletSpan (tuplet) {
     //$module(ExportProcessors.mss)
     /*
         Shifts the tuplet object to a tupletSpan object. This is
@@ -185,9 +183,6 @@ function ShiftTupletToTupletSpan (tuplet, layer) {
 
     tupletSpan = libmei.TupletSpan();
     libmei.SetAttributes(tupletSpan, tuplet.attrs);
-    tupletSpan._property:AddedToMeasure = False;
-
-    layer._property:ActiveTupletId = tupletSpan._id;
 
     if (tuplet._parent != null)
     {
@@ -199,6 +194,12 @@ function ShiftTupletToTupletSpan (tuplet, layer) {
         libmei.RemoveChild(pobj, tuplet);
         tuplet._parent = null;
     }
+
+    mobjs = Self._property:MeasureObjects;
+    mobjs.Push(tupletSpan._id);
+    Self._property:MeasureObjects = mobjs;
+    
+    return tupletSpan;
 }  //$end
 
 function ProcessLyric (lyricobj, objectPositions) {

--- a/src/Utilities.mss
+++ b/src/Utilities.mss
@@ -234,25 +234,84 @@ function TupletsEqual (t, t2) {
 
 }  //$end
 
-function IsLastNoteInTuplet (bobj) {
+function CountTupletsEndingAtNoteRest(noteRest) {
     //$module(Utilities.mss)
-    next_obj = bobj.NextItem(bobj.VoiceNumber, 'NoteRest');
-
-    if (next_obj = null)
+    tuplet = noteRest.ParentTupletIfAny;
+  
+    if (tuplet = null)
     {
-        return true;
+        return 0;
     }
+  
+    nextNoteRest = noteRest.NextItem(noteRest.VoiceNumber, 'NoteRest');
 
-    tuplet = bobj.ParentTupletIfAny;
-    next_obj_tuplet = next_obj.ParentTupletIfAny;
-
-    if (next_obj_tuplet = null or tuplet.Position != next_obj_tuplet.Position)
+    if (nextNoteRest = null or nextNoteRest.ParentTupletIfAny = null)
     {
-        return true;
+        return GetSibTupletDepth(noteRest);
     }
+    
+    if (TupletsEqual(tuplet, nextNoteRest.ParentTupletIfAny))
+    {
+        return 0;
+    }
+    
+    tupletDepth = GetSibTupletDepth(noteRest);
+    nextTupletDepth = GetSibTupletDepth(nextNoteRest);
+    nextTuplet = nextNoteRest.ParentTupletIfAny;
+    numberOfEndingTuplets = 0;
+    
+    // We need to check to which depth the tuplets are equal.
+    // First of all, we have to make sure we are starting at the same depth if
+    // depths are note equal.
+    if (tupletDepth > nextTupletDepth)
+    {
+        for i = nextTupletDepth to tupletDepth
+        {
+            tuplet = tuplet.ParentTupletIfAny;
+        }
+        numberOfEndingTuplets = tupletDepth - nextTupletDepth;
+    }
+    else
+    {
+        for i = tupletDepth to nextTupletDepth
+        {
+            nextTuplet = nextTuplet.ParentTupletIfAny;
+        }
+    }
+    
+    // We are looking for the highest index where both stacks are identical.
+    while ((tuplet != null) and not(TupletsEqual(tuplet, nextTuplet)))
+    {
+        numberOfEndingTuplets = numberOfEndingTuplets + 1;
+        tuplet = tuplet.ParentTupletIfAny;
+        nextTuplet = nextTuplet.ParentTupletIfAny;
+    }
+    
+    return numberOfEndingTuplets;
+}  //$end
 
-    return false;
+function GetMeiTupletDepth (layer) {
+    //$module(Utilities.mss)
+    depth = 0;
+    tuplet = layer._property:ActiveMeiTuplet;
+    while (tuplet != null)
+    {
+        depth = depth + 1;
+        tuplet = tuplet._property:ParentTuplet;
+    }
+    return depth;
+}  //$end
 
+function GetSibTupletDepth (noteRest) {
+    //$module(Utilities.mss)
+    depth = 0;
+    tuplet = noteRest.ParentTupletIfAny;
+    while (tuplet != null)
+    {
+        depth = depth + 1;
+        tuplet = tuplet.ParentTupletIfAny;
+    }
+    return depth;
 }  //$end
 
 function lstrip (str) {


### PR DESCRIPTION
This is a rewrite of `ProcessTuplet()` and related code to support nested tuplets. I've implemented two variants for keeping track of and comparing tuplet nesting between notes. One uses a linked list (this pull request), the other one (#68) an array representing a tuplet stack. Which method is preferable?

[nested-tuplets.sib.zip](https://github.com/music-encoding/sibmei/files/784838/nested-tuplets.sib.zip)