### PR TITLE
Ignore empty lyric items

### DIFF
--- a/src/ExportProcessors.mss
+++ b/src/ExportProcessors.mss
@@ -184,6 +184,12 @@ function ProcessLyric (lyricobj, objectPositions) {
         syllables in an array until we reach the end of the word, and then
         attach them to the notes.
     */
+  
+    if (lyricobj.Text = '')
+    {
+        return null;
+    }
+  
     styleparts = MSplitString(lyricobj.StyleId, '.');
     verse_id = styleparts[5];
     verse_id_arr = MSplitString(verse_id, false);


### PR DESCRIPTION
I had trouble with places like this:

[empty-lyric-items.sib.zip](https://github.com/music-encoding/sibmei/files/836117/empty-lyric-items.sib.zip)

For some reason there are empty lyrics that cause situations like

    <note xml:id="m-42" dur="8" dur.ges="128p" oct="4" pname="d" pnum="62" stem.dir="up">
        <verse xml:id="m-52" n="1">
            <syl xml:id="m-53" wordpos="i"/>
        </verse>
        <verse xml:id="m-54" n="1">
            <syl xml:id="m-55" wordpos="i">o</syl>
        </verse>
    </note>

and

    <note xml:id="m-49" dur="4" dur.ges="256p" oct="4" pname="d" pnum="62" stem.dir="up">
        <verse xml:id="m-58" n="1">
            <syl xml:id="m-59" wordpos="i"/>
        </verse>
    </note>

This pull request avoids this, but could it break anything?