### PR TITLE
Support @plist, @endid etc. on spanners

### DIFF
--- a/src/ExportConverters.mss
+++ b/src/ExportConverters.mss
@@ -806,7 +806,7 @@ function ConvertPositionWithDurationToTimestamp (bobj) {
     startBarNum = startBar.BarNumber;
     endBarNum = bobj.EndBarNumber;
     endBar = startBar.ParentStaff.NthBar(endBarNum);
-    endPosition = bobj.EndPosition;
+    endPosition = NormalizedEndPosition(bobj);
     measureDuration = endBarNum - startBarNum;
     position = ConvertPositionToTimestamp(endPosition, endBar);
 

--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -140,6 +140,9 @@ function GenerateMEIMusic () {
     Self._property:SystemBreak = null;
     Self._property:FrontMatter = CreateDictionary();
 
+    // Track active spanners staff by staff
+    Self._property:ActiveSpannerByStaff = CreateSparseArray();
+
     // grab some global markers from the system staff
     // This will store it for later use.
     ProcessSystemStaff(score);
@@ -287,6 +290,9 @@ function GenerateMEIMusic () {
             libmei.AddChild(section, m);
         }
     }
+
+    // End any remaining active spanners
+    ProcessActiveSpanners(null, null);
 
     return music;
 }  //$end
@@ -892,6 +898,8 @@ function GenerateNoteRest (bobj, layer) {
         libmei.AddAttribute(nr, 'stem.mod', stemmod);
     }
 
+    ProcessActiveSpanners(bobj, nr._id);
+
     return nr;
 }  //$end
 
@@ -1463,7 +1471,15 @@ function GenerateLine (bobj) {
         return null;
     }
 
-    line = AddBarObjectInfoToElement(bobj, line);
+    bobj._property:Plist = CreateSparseArray();
+
+    // We add this spanner to the linked list of active spanners
+    staffNum = bobj.ParentBar.ParentStaff.StaffNum;
+    activeSpannerByStaff = Self._property:ActiveSpannerByStaff;
+    bobj._property:NextActiveSpanner = activeSpannerByStaff[staffNum];
+    activeSpannerByStaff[staffNum] = bobj;
+
+    bobj._property:MeiElement = line;
 
     return line;
 }  //$end


### PR DESCRIPTION
For me this is especially important for `<octave>` to carry over explicitly what notes are affected by the `<octave>` transposition, but should also be useful for any other spanner/line-like object.

Previously, no info where a line ends was encoded.

[ottavas.sib.zip](https://github.com/music-encoding/sibmei/files/869919/ottavas.sib.zip)
