### PR TITLE
Treat line-like and symbol-like trills as separate things

### DIFF
--- a/src/ExportConverters.mss
+++ b/src/ExportConverters.mss
@@ -806,7 +806,7 @@ function ConvertPositionWithDurationToTimestamp (bobj) {
     startBarNum = startBar.BarNumber;
     endBarNum = bobj.EndBarNumber;
     endBar = startBar.ParentStaff.NthBar(endBarNum);
-    endPosition = bobj.EndPosition;
+    endPosition = NormalizedEndPosition(bobj);
     measureDuration = endBarNum - startBarNum;
     position = ConvertPositionToTimestamp(endPosition, endBar);
 

--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -1430,9 +1430,8 @@ function GenerateLine (bobj) {
         }
         case ('Trill')
         {
-            line = GenerateTrill(bobj);
-            // NB: Return here since the trill already has its properties set.
-            return line;
+            line = libmei.Trill();
+            libmei.AddAttribute(line, 'extender', 'true');
         }
         case ('Line')
         {
@@ -1482,26 +1481,6 @@ function GenerateLine (bobj) {
     bobj._property:MeiElement = line;
 
     return line;
-}  //$end
-
-
-function GenerateTrill (bobj) {
-    //$module(ExportGenerators.mss)
-    /* There are two types of trills in Sibelius: A line object and a
-        symbol object. This method normalizes both of these.
-    */
-    trill = libmei.Trill();
-    bar = bobj.ParentBar;
-    obj = GetNoteObjectAtPosition(bobj);
-
-    if (obj != null)
-    {
-        libmei.AddAttribute(trill, 'startid', '#' & obj._id);
-    }
-
-    trill = AddBarObjectInfoToElement(bobj, trill);
-
-    return trill;
 }  //$end
 
 

--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -140,6 +140,9 @@ function GenerateMEIMusic () {
     Self._property:SystemBreak = null;
     Self._property:FrontMatter = CreateDictionary();
 
+    // Track active spanners staff by staff
+    Self._property:ActiveSpannerByStaff = CreateSparseArray();
+
     // grab some global markers from the system staff
     // This will store it for later use.
     ProcessSystemStaff(score);
@@ -287,6 +290,9 @@ function GenerateMEIMusic () {
             libmei.AddChild(section, m);
         }
     }
+
+    // End any remaining active spanners
+    ProcessActiveSpanners(null, null);
 
     return music;
 }  //$end
@@ -892,6 +898,8 @@ function GenerateNoteRest (bobj, layer) {
         libmei.AddAttribute(nr, 'stem.mod', stemmod);
     }
 
+    ProcessActiveSpanners(bobj, nr._id);
+
     return nr;
 }  //$end
 
@@ -1463,7 +1471,15 @@ function GenerateLine (bobj) {
         return null;
     }
 
-    line = AddBarObjectInfoToElement(bobj, line);
+    bobj._property:Plist = CreateSparseArray();
+
+    // We add this spanner to the linked list of active spanners
+    staffNum = bobj.ParentBar.ParentStaff.StaffNum;
+    activeSpannerByStaff = Self._property:ActiveSpannerByStaff;
+    bobj._property:NextActiveSpanner = activeSpannerByStaff[staffNum];
+    activeSpannerByStaff[staffNum] = bobj;
+
+    bobj._property:MeiElement = line;
 
     return line;
 }  //$end

--- a/src/ExportProcessors.mss
+++ b/src/ExportProcessors.mss
@@ -498,7 +498,8 @@ function ProcessSymbol (sobj) {
         case ('32')
         {
             // trill
-            trill = GenerateTrill(sobj);
+            trill = libmei.Trill();
+            trill = AddBarObjectInfoToElement(sobj, trill);
             mlines = Self._property:MeasureObjects;
             mlines.Push(trill._id);
         }


### PR DESCRIPTION
This builds on top of #77 so that trills also get `@tstamp2`, `@plist`, `@endid` etc.  Simpler than having a common function that tries to handle both types of trills.