### PR TITLE
Implement figured bass

### DIFF
--- a/src/ExportConverters.mss
+++ b/src/ExportConverters.mss
@@ -985,6 +985,7 @@ function ConvertFbFigures (fb, bobj) {
 
     n = 1;
     currentLine = '';
+    altsym = null;
     components = bobj.TextWithFormatting;
 
     // Strangely, components.Length is null, so we can't use a for loop.
@@ -1004,6 +1005,11 @@ function ConvertFbFigures (fb, bobj) {
                 libmei.SetText(f, currentLine);
                 libmei.AddAttribute(f, 'n', n);
                 libmei.AddChild(fb, f);
+                if (altsym != null)
+                {
+                    libmei.AddAttribute(f, 'altsym', altsym);
+                    altsym = null;
+                }
             }
             n = n + 1;
             currentLine = '';
@@ -1031,6 +1037,7 @@ function ConvertFbFigures (fb, bobj) {
                             // with two entries: The normalized format and the SMuFL
                             // codepoint.
                             currentLine = currentLine & outputChar[0];
+                            altsym = GenerateSmuflAltsym(outputChar[1], outputChar[2]);
                         }
                         else
                         {

--- a/src/ExportConverters.mss
+++ b/src/ExportConverters.mss
@@ -933,6 +933,15 @@ function ConvertText (textobj) {
             libmei.AddChild(tempo, atext);
             return tempo;
         }
+        case ('text.staff.space.figuredbass')
+        {
+            harm = libmei.Harm();
+            harm = AddBarObjectInfoToElement(textobj, harm);
+            fb = libmei.Fb();
+            libmei.AddChild(harm, fb);
+            ConvertFbFigures(fb, textobj);
+            return harm;
+        }
         default
         {
             return null;
@@ -959,6 +968,79 @@ function ConvertTextElement (textobj) {
     }
 
     return obj;
+}  //$end
+
+function ConvertFbFigures (fb, bobj) {
+    //$module(ExportConverters)
+    if (Self._property:FigbassCharMap = null)
+    {
+        Self._property:FigbassCharMap = InitFigbassCharMap();
+    }
+    if (Self._property:FigbassSmuflMap = null)
+    {
+        Self._property:FigbassSmuflMap = CreateDictionary();
+    }
+    figbassCharMap = Self._property:FigbassCharMap;
+    figbassSmuflMap = Self._property:FigbassSmuflMap;
+
+    n = 1;
+    currentLine = '';
+    components = bobj.TextWithFormatting;
+
+    // Strangely, components.Length is null, so we can't use a for loop.
+    // We want one more iteration than we have components, hence we start at
+    // -1.
+    i = -1;
+    while ((i = -1) or (component != null))
+    {
+        i = i + 1;
+        component = components[i];
+        if ((component = null) or (component = '\\n\\'))
+        {
+            // We reached a linebreak or the last component
+            if (currentLine != '')
+            {
+                f = libmei.F();
+                libmei.SetText(f, currentLine);
+                libmei.AddAttribute(f, 'n', n);
+                libmei.AddChild(fb, f);
+            }
+            n = n + 1;
+            currentLine = '';
+        }
+        else
+        {
+            if (CharAt(component, 0) != '\\')
+            {
+                // We ignore formatting, i.e. text that is encoded with leading '\'
+                for j = 0 to Length(component)
+                {
+                    sibChar = CharAt(component, j);
+                    outputChar = figbassCharMap[sibChar];
+                    if (outputChar = null)
+                    {
+                        // Char is not in map => Convert literally
+                        currentLine = currentLine & sibChar;
+                    }
+                    else
+                    {
+                        if (IsObject(outputChar))
+                        {
+                            // This is a special char that we output in normalized form
+                            // with a reference to a SMuFL glyph. outputChar is an array
+                            // with two entries: The normalized format and the SMuFL
+                            // codepoint.
+                            currentLine = currentLine & outputChar[0];
+                        }
+                        else
+                        {
+                            currentLine = currentLine & outputChar;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }  //$end
 
 function ConvertEndingValues (styleid) {

--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -178,6 +178,7 @@ function GenerateMEIMusic () {
     libmei.AddChild(mdiv, sco);
 
     scd = sibmei2.GenerateScoreDef(score);
+    Self._property:MainScoreDef = scd;
     libmei.AddChild(sco, scd);
 
     barmap = ConvertSibeliusStructure(score);
@@ -1802,4 +1803,38 @@ function GenerateFormattedString (bobj) {
     }
 
     return ret;
+}  //$end
+
+function GenerateSmuflAltsym (glyphnum, glyphname) {
+    //$module(ExportGenerators.mss)
+    if (Self._property:SmuflSymbolIds = null)
+    {
+        Self._property:SmuflSymbolIds = CreateDictionary();
+    }
+    symbolIds = Self._property:SmuflSymbolIds;
+
+    if (symbolIds[glyphnum] = null)
+    {
+        if (Self._property:SymbolTable = null)
+        {
+            symbolTable = libmei.SymbolTable();
+            libmei.AddChild(Self._property:MainScoreDef, symbolTable);
+            Self._property:SymbolTable = symbolTable;
+        }
+        symbolTable = Self._property:SymbolTable;
+
+        symbolDef = libmei.SymbolDef();
+        libmei.AddChild(symbolTable, symbolDef);
+        anchoredText = libmei.AnchoredText();
+        libmei.AddChild(symbolDef, anchoredText);
+        symbol = libmei.Symbol();
+        libmei.AddChild(anchoredText, symbol);
+        libmei.AddAttribute(symbol, 'authority', 'SMuFL');
+        libmei.AddAttribute(symbol, 'glyphnum', glyphnum);
+        libmei.AddAttribute(symbol, 'glyphname', glyphname);
+
+        symbolIds[glyphnum] = symbolDef._id;
+    }
+
+    return '#' & symbolIds[glyphnum];
 }  //$end

--- a/src/Utilities.mss
+++ b/src/Utilities.mss
@@ -48,7 +48,7 @@ function PrevPow2 (val) {
     val = utils.bwOR(val, utils.shr(val, 4));
     val = utils.bwOR(val, utils.shr(val, 8));
     val = utils.bwOR(val, utils.shr(val, 16));
-    // this might be a hack, but I wrote it in 
+    // this might be a hack, but I wrote it in
     // a power outage with no internet.
     // we get the next power of two, and then
     // divide by two to get the previous one.
@@ -58,7 +58,7 @@ function PrevPow2 (val) {
 
 function SimpleNoteHash (nobj) {
     //$module(Utilities.mss)
-    /* 
+    /*
         Generate a simple note hash. Not guaranteed to be unique given
         any suitably large sample of notes, but should be unique enough for quick
         checks.
@@ -250,12 +250,12 @@ function GetTupletStack (bobj) {
 function CountTupletsEndingAtNoteRest(noteRest) {
     //$module(Utilities.mss)
     tuplet = noteRest.ParentTupletIfAny;
-  
+
     if (tuplet = null)
     {
         return 0;
     }
-  
+
     nextNoteRest = noteRest.NextItem(noteRest.VoiceNumber, 'NoteRest');
 
     if (nextNoteRest = null or nextNoteRest.ParentTupletIfAny = null)
@@ -263,23 +263,23 @@ function CountTupletsEndingAtNoteRest(noteRest) {
         tupletStack = GetTupletStack(noteRest);
         return tupletStack.Length;
     }
-    
+
     if (TupletsEqual(tuplet, nextNoteRest.ParentTupletIfAny))
     {
         return 0;
     }
-    
+
     tupletStack = GetTupletStack(noteRest);
     nextTupletStack = GetTupletStack(nextNoteRest);
-    
+
     // We are looking for the highest index where both stacks are identical.
     index = utils.min(tupletStack.Length, nextTupletStack.Length) - 1;
-    
+
     while (index >= 0 and not(TupletsEqual(tupletStack[index], nextTupletStack[index])))
     {
         index = index - 1;
     }
-    
+
     return tupletStack.Length - 1 - index;
 }  //$end
 
@@ -339,7 +339,7 @@ function NormalizedBeamProp (noteRest) {
     {
         return NoBeam;
     }
-    
+
     // At this point, we're only dealing with ContinueBeam and SingleBeam.
     // We need to look at the preceding note to see whether there's any
     // beam to continue.
@@ -347,24 +347,24 @@ function NormalizedBeamProp (noteRest) {
     if (noteRest.Beam != StartBeam)
     {
         prev_obj = PrevNormalOrGrace(noteRest, noteRest.GraceNote);
-        
+
         if (prev_obj != null and prev_obj.Beam != NoBeam and prev_obj.Duration < 256)
         {
             // We actually have a beam we can continue.
             if (noteRest.Beam = SingleBeam and noteRest.Duration < 128 and prev_obj.Duration < 128)
             {
-                // SingleBeam only makes sense if we actually have secondary beams between the 
+                // SingleBeam only makes sense if we actually have secondary beams between the
                 // previous note and the current note.
                 return SingleBeam;
             }
             return ContinueBeam;
         }
     }
-    
+
     // At this point, we know there is no previous beam we can continue because we have a
     // StartBeam or the above test for a previous beam failed.
     // We still need to check whether there is a following note that we can beam to.
-    
+
     next_obj = NextNormalOrGrace(noteRest, noteRest.GraceNote);
     if (next_obj != null and next_obj.Duration < 256 and (next_obj.Beam = ContinueBeam or next_obj.Beam = SingleBeam))
     {
@@ -381,9 +381,9 @@ function NextNormalOrGrace (noteRest, grace) {
     /*
         When given a 'normal' NoteRest, this function returns the next 'normal' NoteRest
         in the same voice.
-        When given a grace NoteRest, this function returns the immediately adjacent 
+        When given a grace NoteRest, this function returns the immediately adjacent
         following grace NoteRest, if existant.
-        This function is basically a duplicate of PrevNormalOrGrace() with 
+        This function is basically a duplicate of PrevNormalOrGrace() with
         'Previous' replaced by 'Next'.
     */
     next_obj = noteRest.NextItem(noteRest.VoiceNumber, 'NoteRest');
@@ -411,7 +411,7 @@ function PrevNormalOrGrace (noteRest, grace) {
     //$module(Utilities.mss)
     /*
         For a description, see NextNormalOrGrace().
-        This function is basically a duplicate of PrevNormalOrGrace() with 
+        This function is basically a duplicate of PrevNormalOrGrace() with
         'Next' replaced by 'Previous'.
     */
     prev_obj = noteRest.PreviousItem(noteRest.VoiceNumber, 'NoteRest');
@@ -538,17 +538,17 @@ function InitFigbassCharMap () {
         '}', '9+',
         'Å', '|',
         'ü', '_',
-        '©', CreateSparseArray('2♯', 'U+EA53'), // 2 with slashed foot
-        'Ä', CreateSparseArray('4♯', 'U+EA56'), // 4 with slashed horizontal line
-        'Ë', CreateSparseArray('5♯', 'U+EA58'), // 5 with straight slash through head
-        'Ï', CreateSparseArray('5♯', 'U+EA59'), // 5 with angled slash through head
-        'ï', CreateSparseArray('5♯', 'U+EA5A'), // 5 with slashed foot
-        '´', CreateSparseArray('6♯', 'U+EA6F'), // 6 with slashed head
-        'ä', CreateSparseArray('7♯', 'U+EA5E'), // 7 with slashed head
-        '&', CreateSparseArray('7♯', 'U+EA5F'), // 7 with slashed stem
+        '©', CreateSparseArray('2♯', 'U+EA53', 'figbass2Raised' ), // 2 with slashed foot
+        'Ä', CreateSparseArray('4♯', 'U+EA56', 'figbass4Raised' ), // 4 with slashed horizontal line
+        'Ë', CreateSparseArray('5♯', 'U+EA58', 'figbass5Raised1'), // 5 with straight slash through head
+        'Ï', CreateSparseArray('5♯', 'U+EA59', 'figbass5Raised2'), // 5 with angled slash through head
+        'ï', CreateSparseArray('5♯', 'U+EA5A', 'figbass5Raised3'), // 5 with slashed foot
+        '´', CreateSparseArray('6♯', 'U+EA6F', 'figbass6Raised' ), // 6 with slashed head
+        'ä', CreateSparseArray('7♯', 'U+EA5E', 'figbass7Raised1'), // 7 with slashed head
+        '&', CreateSparseArray('7♯', 'U+EA5F', 'figbass8Raised2'), // 7 with slashed stem
         // (Sibelius/Opus and SMuFL/Bravura don't match 100% for the slashed 9:
         // Opus slashes the stem, Bravura the head)
-        'ö', CreateSparseArray('9#', 'U+EA62')  // slashed 9
+        'ö', CreateSparseArray('9#', 'U+EA62', 'figbass9Raised')   // slashed 9
     );
     literalChars = '0123456789[]_-+.';
     for i = 0 to Length(literalChars)

--- a/src/Utilities.mss
+++ b/src/Utilities.mss
@@ -462,3 +462,100 @@ function GetNongraceParentBeam (noteRest, layer) {
     return null;
 }  //$end
 
+function InitFigbassCharMap () {
+    //$module(Utilities.mss)
+    map = CreateDictionary(
+        '§', '♮',
+        '#', '♯',
+        '!', '♭',
+        '?', '𝄪',
+        '%', '𝄫',
+        'a', '(2)',
+        'i', '[2]',
+        'w', '2♮',
+        's', '2♯',
+        'x', '2♭',
+        'W', '♮2',
+        'S', '♯2',
+        'X', '♭2',
+        'k', '2+',
+        'p', '(3)',
+        'q', '[3]',
+        'e', '3♮',
+        'd', '3♯',
+        'c', '3♭',
+        'E', '♮3',
+        'D', '♯3',
+        'C', '♭3',
+        'z', '3+',
+        'A', '(4)',
+        'I', '[4]',
+        'r', '4♮',
+        'f', '4♯',
+        'v', '4♭',
+        'R', '♮4',
+        'F', '♯4',
+        'V', '♭4',
+        'K', '4+',
+        'P', '(5)',
+        'Q', '[5]',
+        't', '5♮',
+        'g', '5♯',
+        'b', '5♭',
+        'T', '♮5',
+        'G', '♯5',
+        'B', '♭5',
+        'Z', '5+',
+        '$', '(6)',
+        '¨', '[6]',
+        'y', '6♮',
+        'h', '6♯',
+        'n', '6♭',
+        'Y', '♮6',
+        'H', '♯6',
+        'N', '♭6',
+        ',', '6+',
+        'Â', '(7)',
+        ';', '[7]',
+        'u', '7♮',
+        'j', '7♯',
+        'm', '7♭',
+        'U', '♮7',
+        'J', '♯7',
+        'M', '♭7',
+        '<', '7+',
+        '>', '+7',
+        '=', '(8)',
+        'Ö', '[8]',
+        'À', '(9)',
+        '{', '[9]',
+        'o', '9♮',
+        'l', '9♯',
+        'ë', '9♭',
+        'O', '♮9',
+        'L', '♯9',
+        ':', '♭9',
+        '}', '9+',
+        'Å', '|',
+        'ü', '_',
+        '©', CreateSparseArray('2♯', 'U+EA53'), // 2 with slashed foot
+        'Ä', CreateSparseArray('4♯', 'U+EA56'), // 4 with slashed horizontal line
+        'Ë', CreateSparseArray('5♯', 'U+EA58'), // 5 with straight slash through head
+        'Ï', CreateSparseArray('5♯', 'U+EA59'), // 5 with angled slash through head
+        'ï', CreateSparseArray('5♯', 'U+EA5A'), // 5 with slashed foot
+        '´', CreateSparseArray('6♯', 'U+EA6F'), // 6 with slashed head
+        'ä', CreateSparseArray('7♯', 'U+EA5E'), // 7 with slashed head
+        '&', CreateSparseArray('7♯', 'U+EA5F'), // 7 with slashed stem
+        // (Sibelius/Opus and SMuFL/Bravura don't match 100% for the slashed 9:
+        // Opus slashes the stem, Bravura the head)
+        'ö', CreateSparseArray('9#', 'U+EA62')  // slashed 9
+    );
+    literalChars = '0123456789[]_-+.';
+    for i = 0 to Length(literalChars)
+    {
+        char = CharAt(literalChars, i);
+        map[char] = char;
+    }
+
+    return map;
+}  //$end


### PR DESCRIPTION
This feature was created to fit the needs of a project at the [ÖAW](https://www.oeaw.ac.at/ikm/home/) (Austrian Academy of Sciences). Some functionality, e.g. "progression lines", is still very basic.

Example file: [figbass_symbols.sib.zip](https://github.com/music-encoding/sibmei/files/1059303/figbass_symbols.sib.zip)

The approach we took is to normalize all figures to digits and Unicode accidentals, even for strike-through symbols. This has two reasons:

* Using SMuFL characters from the private use area directly in the text might lead to strange results.
* We hope the normalized data is more accessible to analysis, database applications and the like.

To not lose the information about special figures, we created `<symbolDefs>` for each encountered SMuFL character and pointed to it using `@altsym`.