### PR TITLE
Fixed: Gestural duration of notes within a tuplet.

### DIFF
--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -962,7 +962,7 @@ function GenerateNote (nobj) {
         ptuplet = nobj.ParentNoteRest.ParentTupletIfAny;
         pnum = ptuplet.Left;
         pden = ptuplet.Right;
-        floatgesdur = (pnum & '.0' / pden & '.0') * dur;
+        floatgesdur = (pden & '.0' / pnum & '.0') * dur;
         gesdur = Round(floatgesdur);
     }
     else


### PR DESCRIPTION
Previously the gestural duration of a note had a larger value when it was part of a `<tuplet>` than when it stood alone. This commit fixes this by inverting the ratio by which the duration is multiplied. The gestural duration (`@dur.ges`) of the stand alone note is now multiplied by the ratio `@numbase/@num` to get the `@dur.ges` of the `<note>` element when it is part of a `<tuplet>`.

Fixes https://github.com/music-encoding/sibmei/issues/90