### PR TITLE
Prevent multi-bar lines from crashing sibmei

### DIFF
--- a/src/Utilities.mss
+++ b/src/Utilities.mss
@@ -95,6 +95,11 @@ function GetNoteObjectAtEndPosition (bobj) {
 
     staffObjectPositions = objectPositions[staff_num];
     barObjectPositions = staffObjectPositions[bar_num];
+    if (null = barObjectPositions) {
+        // TODO: We have a line that continues into a 'future' bar. Track these
+        // lines and add IDs when we've reached the end NoteRest and know its ID
+        return null;
+    }
     voiceObjectPositions = barObjectPositions[voice_num];
 
     if (voiceObjectPositions = null)
@@ -235,7 +240,7 @@ function AddBarObjectInfoToElement (bobj, element) {
         }
         case('Slur')
         {
-            // libmei.AddAttribute(element, 'tstamp2', ConvertPositionWithDurationToTimestamp(bobj));
+            libmei.AddAttribute(element, 'tstamp2', ConvertPositionWithDurationToTimestamp(bobj));
             start_obj = GetNoteObjectAtPosition(bobj);
             end_obj = GetNoteObjectAtEndPosition(bobj);
             if (start_obj != null)

--- a/test/sib-test/TestExportGenerators.mss
+++ b/test/sib-test/TestExportGenerators.mss
@@ -6,6 +6,7 @@ function TestExportGenerators (suite) {
         .Add('TestGenerateMusicWithLyrics')
         .Add('TestGenerateMusicWithEndings')
         .Add('TestGenerateStaffGroups')
+        .Add('TestGenerateLine')
         ;
 } //$end
 
@@ -281,4 +282,25 @@ function TestGenerateStaffGroups (assert, plugin) {
     assert.OK(e, 'The file ' & filePath & ' was successfully generated');
 
     libmei.destroy();
+}  //$end
+
+
+function TestGenerateLine (assert, plugin) {
+    score = CreateEmptyTestScore(1, 2);
+    staff = score.NthStaff(1);
+    // Fill the bars with quarter notes
+    for barNumber = 1 to staff.BarCount + 1 {
+        bar = staff.NthBar(barNumber);
+        for noteNumber = 0 to 4 {
+            bar.AddNote(noteNumber * 256, 60, 256);
+        }
+    }
+
+    // A short slur
+    slur1 = staff.NthBar(1).AddLine(0, 512, 'line.staff.slur.down');
+    // A slur across bars
+    slur2 = staff.NthBar(1).AddLine(512, 1024, 'line.staff.slur.down');
+
+    sibmei2._property:ActiveScore = score;
+    sibmei2.GenerateMEIMusic();
 }  //$end


### PR DESCRIPTION
Sibmei crashed when there is a line across multiple bars. This is a major bug, so we should create a bugfix release.

This is not the ideal solution, but it at least makes things work again.