### PR TITLE
Fixed gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var l = require('fancy-log');
 var Q = require('q');
 var plgconf = require('./plgconfig');
 
-gulp.task('develop:build', function(callback)
+function build()
 {
     var deferred = Q.defer();
     l.info(c.blue('Copying "linked" libraries'));
@@ -40,9 +40,9 @@ gulp.task('develop:build', function(callback)
         .pipe(gulp.dest(destPath));
 
     return deferred.promise;
-});
+};
 
-gulp.task('develop:deploy', function()
+function deploy (cb)
 {
     var deploy = child.exec('deployPlg', function(err, stdout, stderr)
     {
@@ -52,14 +52,11 @@ gulp.task('develop:deploy', function()
         }
         l.info(c.blue('Output: ') + '\n' + stdout);
     });
-});
+    cb();
+};
 
-gulp.task('develop', function()
-{
-    gulp.watch(['src/**/*', 'test/**/*', 'lib/**/*.plg'], gulp.series('develop:build', 'develop:deploy'))
-});
+function develop() {
+  gulp.watch(['src/**/*', 'test/**/*', 'lib/**/*.plg'], gulp.series(build, deploy))
+}
 
-gulp.task('default', function()
-{
-    gulp.start('develop')
-});
+exports.develop = develop;


### PR DESCRIPTION
After the last changes for gulp version 4.0.2 the watcher triggered only once.
To fix this, I adjusted the callback in the build function.
Also, I switched from gulp task() to exported functions since this is now the recommended method; see [task()](https://gulpjs.com/docs/en/api/task).

I am not 100% sure if the callback fix is the best way to do it; it works now...
@th-we Could you please have a look? -> [gulp Async Completion](https://gulpjs.com/docs/en/getting-started/async-completion) 
It seems like you could use promises without the q package, but I am familiar enough with that.