### PR TITLE
Fixed test: creates correct character entities on elisions

### DIFF
--- a/test/mocha/test-lyrics.js
+++ b/test/mocha/test-lyrics.js
@@ -32,7 +32,7 @@ describe("Lyrics", () => {
       assert.strictEqual(sylsWithCon.length, 1);
     });
     it("creates correct character entities on elisions", function() {
-      assert.strictEqual(syls[13].firstChild._data, "n'u");
+      assert.strictEqual(syls[13].textContent, "n'u");
     });
   });
 


### PR DESCRIPTION
`syls[13].firstChild._data` returned undefined, used `syls[13].firstChild.F` instead.
**F** is really not a very intuitive variable, but it seems like this is the way to get the text of an element according to the JSON returned when querying for the whole element...

