### PR TITLE
Don't reference libmei4 in Initialize()

### DIFF
--- a/plgconfig.js
+++ b/plgconfig.js
@@ -7,7 +7,7 @@ var config = {
   plgCategory:    'MEI Export',
   pluginFilename: 'sibmei4.plg',
   linkLibraries: [
-   'libmei4.plg', 'sibmei4_batch_mxml.plg', 'sibmei4_batch_sib.plg'
+    'libmei4.plg', 'sibmei4_batch_mxml.plg', 'sibmei4_batch_sib.plg', 'sibmei4_test_runner.plg'
   ],
   importDir:      './import',
   buildDir:       './build',

--- a/src/Initialize.mss
+++ b/src/Initialize.mss
@@ -1,6 +1,5 @@
 function Initialize() {
     Self._property:Logfile = GetTempDir() & LOGFILE;
-    Self._property:libmei = libmei4;
 
     if (Sibelius.FileExists(Self._property:Logfile) = False)
     {

--- a/src/Run.mss
+++ b/src/Run.mss
@@ -2,6 +2,7 @@ function Run() {
     //$module(Run.mss)
 
     // first, ensure we're running with a clean slate.
+    Self._property:libmei = libmei4;
     libmei.destroy();
 
     // do some preliminary checks
@@ -80,4 +81,3 @@ function DoExport (filename) {
     // clean up after ourself
     libmei.destroy();
 }  //$end
-

--- a/src/Run.mss
+++ b/src/Run.mss
@@ -1,10 +1,6 @@
 function Run() {
     //$module(Run.mss)
 
-    // first, ensure we're running with a clean slate.
-    Self._property:libmei = libmei4;
-    libmei.destroy();
-
     // do some preliminary checks
     if (Sibelius.ProgramVersion < 7000)
     {
@@ -44,6 +40,10 @@ function Run() {
 
 function DoExport (filename) {
     //$module(Run.mss)
+
+    // first, ensure we're running with a clean slate.
+    Self._property:libmei = libmei4;
+    libmei.destroy();
 
     // Deal with the Progress GUI
     // set the active score here so we can refer to it throughout the plugin

--- a/test/sib-test/Run.mss
+++ b/test/sib-test/Run.mss
@@ -1,6 +1,7 @@
 function Run() {
   Self._property:libmei = libmei4;
   Self._property:sibmei = sibmei4;
+  sibmei4._property:libmei = libmei;
 
   plugins = Sibelius.Plugins;
 

--- a/test/sib-test/Run.mss
+++ b/test/sib-test/Run.mss
@@ -1,11 +1,7 @@
-function Initialize() {
-  //$module(Run.mss)
+function Run() {
   Self._property:libmei = libmei4;
   Self._property:sibmei = sibmei4;
-}  //$end
 
-
-function Run() {
   plugins = Sibelius.Plugins;
 
   if (not (plugins.Contains('Test'))) {


### PR DESCRIPTION
libmei4.plg might not be loaded yet when Initialize() is run.

I didn't detect this problem when developing with unload/reload methods – it only occurs when re-starting Sibelius. This needs to be fixed before releasing v4.

I would be thankful if somebody else could run the tests as well to make sure everything is working smoothly not only on my machine. @annplaksin Could you do that?