### PR TITLE
Make sure we have an active score

### DIFF
--- a/src/Run.mss
+++ b/src/Run.mss
@@ -45,13 +45,18 @@ function DoExport (filename) {
     Self._property:libmei = libmei4;
     libmei.destroy();
 
-    // Deal with the Progress GUI
     // set the active score here so we can refer to it throughout the plugin
     Self._property:ActiveScore = Sibelius.ActiveScore;
+    if (Self._property:ActiveScore = null)
+    {
+        Sibelius.MessageBox('No score to convert. Can not export to ' & filename);
+        return false;
+    }
 
     // Set up the warnings tracker
     Self._property:warnings = CreateSparseArray();
 
+    // Deal with the Progress GUI
     progCount = Sibelius.ActiveScore.SystemStaff.BarCount;
     fn = utils.ExtractFileName(filename);
     progressTitle = utils.Format(_InitialProgressTitle, fn);

--- a/src/Run.mss
+++ b/src/Run.mss
@@ -49,7 +49,7 @@ function DoExport (filename) {
     Self._property:ActiveScore = Sibelius.ActiveScore;
     if (Self._property:ActiveScore = null)
     {
-        Sibelius.MessageBox('No score to convert. Can not export to ' & filename);
+        Sibelius.MessageBox('Could not find an active score. Cannot export to ' & filename);
         return false;
     }
 


### PR DESCRIPTION
I randomly ran into a strange problem where indexing the score object was not ~~accessible~~ possible. This change is in the hope of giving a sensible message in case we for some obscure reason don't have an active score.