### PR TITLE
Fix AddControlEventAttributes() extension interface

### DIFF
--- a/src/Extensions.mss
+++ b/src/Extensions.mss
@@ -179,6 +179,6 @@ function ExtensionAPI_GenerateControlEvent (this, bobj, elementName) {
     GenerateControlEvent(bobj, elementName);
 }   //$end
 
-function ExtensionAPI_AddControlEventAttributes (this, bobj) {
-    AddControlEventAttributes(bobj);
+function ExtensionAPI_AddControlEventAttributes (this, bobj, element) {
+    AddControlEventAttributes(bobj, element);
 }   //$end


### PR DESCRIPTION
The interface of `AddControlEventAttributes()` provided by the extension api didn't contain the parameter `element`.
Now it works.