### PR TITLE
New: support spiccato articulations

### DIFF
--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -894,6 +894,11 @@ function GenerateNoteRest (bobj, layer) {
         libmei.AddAttributeValue(nr, 'artic', 'stacciss');
     }
 
+    if (bobj.GetArticulation(WedgeArtic))
+    {
+        libmei.AddAttributeValue(nr, 'artic', 'spicc');
+    }
+
     if (bobj.GetArticulation(PlusArtic))
     {
         libmei.AddAttributeValue(nr, 'artic', 'stop');

--- a/src/SymbolHandler.mss
+++ b/src/SymbolHandler.mss
@@ -26,6 +26,7 @@ function InitSymbolHandlers () {
             '164', 'HandleModifier',                    //damp (2)
             '165', 'HandleModifier',                    //damp (3)
             '166', 'HandleModifier',                    //damp (4)
+            '211', 'HandleModifier',                    //spiccato
             '212', 'HandleModifier',                    //ten above
             '214', 'HandleModifier',                    //marc above
             '217', 'HandleModifier',                    //upbow above
@@ -74,6 +75,7 @@ function InitSymbolMap () {
         '164', CreateSparseArray('Artic', CreateDictionary('artic','damp')),                    //damp (2)
         '165', CreateSparseArray('Artic', CreateDictionary('artic','damp')),                    //damp (3)
         '166', CreateSparseArray('Artic', CreateDictionary('artic','damp')),                    //damp (4)
+        '211', CreateSparseArray('Artic', CreateDictionary('artic','spicc', 'place','above')),                   //spiccato
         '212', CreateSparseArray('Artic', CreateDictionary('artic','ten', 'place','above')),    //ten above
         '214', CreateSparseArray('Artic', CreateDictionary('artic','marc', 'place','above')),   //marc above
         '217', CreateSparseArray('Artic', CreateDictionary('artic','upbow', 'place','above')),  //upbow above


### PR DESCRIPTION
This commit adds support for spiccato. Sibelius calls this a wedge, but in MusicXML called spiccato. Both note properties and symbol variant are converted. Note property added as attribute of note element, and symbol added as child element.

http://usermanuals.musicxml.com/MusicXML/MusicXML.htm#EL-MusicXML-spiccato.htm%3FTocPath%3DMusicXML%2520Reference%7CScore%2520Schema%2520(XSD)%7CElements%7Cnote%7C_____96