### PR TITLE
Fixed: expose build as a gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,3 +60,4 @@ function develop() {
 }
 
 exports.develop = develop;
+exports.build = build;


### PR DESCRIPTION
This commit exposes the build function as a separate gulp task allowing the user to run gulp build independent of develop.