### PR TITLE
Analyze tool: Recursively process folders

### DIFF
--- a/tools/analyze.js
+++ b/tools/analyze.js
@@ -36,10 +36,20 @@ function reportIssue(filePath, lineIndex, line, message) {
 }
 
 
+function* mssPaths(folder) {
+  for (const item of fs.readdirSync(folder).map(f => path.join(folder, f))) {
+    if (fs.lstatSync(item).isDirectory()) {
+      yield* mssPaths(item);
+    } else if (item.match(/\.mss$/)) {
+      yield item;
+    }
+  }
+}
+
+
 function analyzeUsage(methods, attributes) {
   console.log('Analyze libmei and attribute usage...');
-  for (const fileName of fs.readdirSync(directories.src)) {
-    const filePath = path.join(directories.src, fileName);
+  for (filePath of mssPaths(directories.src)) {
     const lines = fs.readFileSync(filePath, {encoding: 'utf8'}).split("\n");
 
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex ++) {


### PR DESCRIPTION
I ran the attribute setter analysis tool, but it now needs to account for folders and *.msd files in the src folder.