### PR TITLE
Move filename dialog to DoExport() and return filename

### DIFF
--- a/src/Run.mss
+++ b/src/Run.mss
@@ -14,6 +14,12 @@ function Run() {
         return False;
     }
 
+    DoExport(null);
+
+}  //$end
+
+
+function GetExportFileName () {
     // get the active score object
     activeScore = Sibelius.ActiveScore;
 
@@ -28,24 +34,31 @@ function Run() {
 
     if (not InitGlobals(null))
     {
-        return false;
+        return null;
     }
 
     // Ask to the file to be saved somewhere
     filename = Sibelius.SelectFileToSave('Save as...', activeFileName, activePath, 'mei', 'TEXT', 'Music Encoding Initiative');
 
-    if (filename = null)
-    {
-        Sibelius.MessageBox(_ExportFileIsNull);
-        return False;
-    }
+    return filename;
+} //$end
 
-    DoExport(filename);
-
-}  //$end
 
 function DoExport (filename) {
     //$module(Run.mss)
+
+    // Argument filename is optional and will be determined automatically if
+    // `null` is passed in instead.  The filename is also returned so the
+    // caller can then work with.
+    if (null = filename)
+    {
+        filename = GetExportFileName();
+        if (null = filename)
+        {
+            Sibelius.MessageBox(_ExportFileIsNull);
+            return null;
+        }
+    }
 
     if (not Self._property:_Initialized)
     {
@@ -97,4 +110,6 @@ function DoExport (filename) {
 
     // clean up after ourself
     libmei.destroy();
+
+    return filename;
 }  //$end


### PR DESCRIPTION
Like this, project specific export plugins easily use the standard sibmei behavior for determining file names. The returned file name can also be used to trigger postprocessing for the exported file.