### PR TITLE
Fixed: Use corresp instead of startid for fb

### DIFF
--- a/src/TextHandler.mss
+++ b/src/TextHandler.mss
@@ -104,6 +104,15 @@ function TempoTextHandler (this, textObject) {
 function FiguredBassTextHandler (this, textObject) {
     // 'text.staff.space.figuredbass'
     harm = GenerateControlEvent(textObject, 'Harm');
+
+    // uniquely, for figured bass we do not use the startid here,
+    // since a figure can change halfway through a note. So we remove
+    // the startid and replace it with corresp, pointing to the
+    // same ID.
+    startidValue = libmei.GetAttribute(harm, 'startid');
+    libmei.RemoveAttribute(harm, 'startid');
+    libmei.AddAttribute(harm, 'corresp', startidValue);
+
     fb = libmei.Fb();
     libmei.AddChild(harm, fb);
     ConvertFbFigures(fb, textObject);


### PR DESCRIPTION
Changes the `<harm>` element for figured bass to use `@corresp` instead of `@tstamp` for the note that it is attached to. This should still correspond to the nearest previous bar object. This is to deal with situations like the following, where the figure is attached to the first note in the bar, but should be positioned on the third beat.

![image](https://user-images.githubusercontent.com/163183/218492049-74d9f7fd-240d-4c07-8d0b-e998e4e83147.png)

See the discussion in #192 for additional context.

Fixes #192