### PR TITLE
Unify and improve batch export code

### DIFF
--- a/lib/sibmei4_batch_mxml.plg
+++ b/lib/sibmei4_batch_mxml.plg
@@ -8,44 +8,28 @@
     Run "()
     {
         folder = Sibelius.SelectFolder();
-
-        if (IsObject(folder))
+        if (null = folder)
         {
-            sibmei4.InitGlobals(null);
-
-            // count files for progress dialog
-            numFiles = folder.FileCount('XML');
-            index = 0;
-            Sibelius.CreateProgressDialog(_Processing, 0, numFiles);
-
-            for each XML file in folder
-            {
-                index = index + 1;
-                cont = Sibelius.UpdateProgressDialog(index, _File & ' ' & index & ' ' & _Of & ' ' & numFiles);
-
-                if (cont = 0)
-                {
-                    // if user has cancelled export
-                    Sibelius.DestroyProgressDialog();
-                    return 0;
-                }
-
-                // open file
-                of = Sibelius.Open(file.NameWithExt, True);
-
-                if (of = True)
-                {
-                    // NB: DO NOT CHANGE THIS EXTENSION PLEASE.
-                    sibmei4.DoExport(file.Name & '.mei');
-                    Sibelius.CloseWindow(False);
-                }
-            }
-
-            Sibelius.DestroyProgressDialog();
+            return '';
         }
-}"
+
+        files = CreateSparseArray();
+
+        for each XML file in folder
+        {
+            files.Push(file);
+        }
+        for each MUSICXML file in folder
+        {
+            files.Push(file);
+        }
+        for each MXL file in folder
+        {
+            files.Push(file);
+        }
+
+        sibmei4.ExportBatch(files, null);
+    }"
+
     _PluginMenuName "Export MusicXML folder to MEI 4"
-    _Processing "Processing scores"
-    _File "File"
-    _Of "of"
 }

--- a/lib/sibmei4_batch_sib.plg
+++ b/lib/sibmei4_batch_sib.plg
@@ -8,53 +8,20 @@
     Run "()
     {
         folder = Sibelius.SelectFolder();
-        if (null != folder)
+        if (null = folder)
         {
-            ConvertFolder(folder, null);
+            return '';
         }
+
+        files = CreateSparseArray();
+
+        for each SIB file in folder
+        {
+            files.Push(file);
+        }
+
+        sibmei4.ExportBatch(files, null);
     }"
 
-    ConvertFolder "(folder, extensions)
-    {
-
-        if (not IsObject(folder))
-        {
-            Sibelius.MessageBox('Not a folder object: ' & folder);
-        }
-        else
-        {
-            sibmei4.InitGlobals(extensions);
-
-            // count files for progress dialog
-            numFiles = folder.FileCount('SIB');
-            index = 0;
-            Sibelius.CreateProgressDialog(_Processing, 0, numFiles);
-
-            for each SIB file in folder
-            {
-                index = index + 1;
-                cont = Sibelius.UpdateProgressDialog(index, _File & ' ' & index & ' ' & _Of & ' ' & numFiles);
-
-                if (cont = 0) {
-                    // if user has cancelled export
-                    Sibelius.DestroyProgressDialog();
-                    return 0;
-                }
-
-                // open file
-                op = Sibelius.Open(file.NameWithExt, True);
-                if (op = True) {
-                    // NB: DO NOT CHANGE THIS EXTENSION PLEASE.
-                    sibmei4.DoExport(file.Name & '.mei');
-                    Sibelius.CloseWindow(False);
-                }
-            }
-
-            Sibelius.DestroyProgressDialog();
-        }
-    }"
     _PluginMenuName "Export Sibelius folder to MEI 4"
-    _Processing "Processing scores"
-    _File "File"
-    _Of "of"
 }

--- a/src/GLOBALS.mss
+++ b/src/GLOBALS.mss
@@ -7,7 +7,6 @@ _InitialProgressTitle "Exporting %s to MEI"
 _ExportFileIsNull "You must specify a file to save."
 _ScoreError "Please open a score and try again."
 _ExportSuccess "The file was exported successfully."
-_ExportFailure "The file was not exported because of an error."
 _VersionNotSupported "Versions earlier than Sibelius 7 are not supported."
 _ExportingBars "Exporting to MEI: Bar %s of %s"
 

--- a/src/Run.mss
+++ b/src/Run.mss
@@ -132,7 +132,7 @@ function ExportBatch (files, extensions) {
 
     for index = 0 to numFiles
     {
-        file = files[index];
+        file = Sibelius.GetFile(files[index]);
 
         open = Sibelius.Open(file, True);
         if (not open)

--- a/src/Run.mss
+++ b/src/Run.mss
@@ -147,7 +147,14 @@ function ExportBatch (files, extensions) {
         {
             // NB: DO NOT CHANGE THIS EXTENSION PLEASE.
             error = DoExport(file.Name & '.mei');
-            Sibelius.CloseWindow(False);
+            if (Sibelius.ProgramVersion >= 20201200)
+            {
+                Sibelius.CloseAllWindowsForScore(Sibelius.ActiveScore, false);
+            }
+            else
+            {
+                Sibelius.CloseWindow(False);
+            }
             if (null = error)
             {
                 exportCount = exportCount + 1;

--- a/src/Run.mss
+++ b/src/Run.mss
@@ -6,7 +6,12 @@ function Run() {
         return null;
     }
 
-    DoExport(null);
+    error = DoExport(null);
+
+    if (null != error)
+    {
+        Sibelius.MessageBox(error);
+    }
 
 }  //$end
 
@@ -104,13 +109,62 @@ function DoExport (filename) {
         trace('Warning: ' & warning);
     }
 
-    if (export_status = False)
-    {
-        Sibelius.MessageBox(_ExportFailure);
-    }
-
     // clean up after ourself
     libmei.destroy();
 
-    return filename;
+    if (export_status = False)
+    {
+        return 'The file was not exported. File:\n\n' & filename & '\n\ncould not be written.';
+    }
+}  //$end
+
+
+function ExportBatch (files, extensions) {
+    if (not InitGlobals(extensions))
+    {
+        return null;
+    }
+
+    utils.SortArray(files, false);
+
+    numFiles = files.Length;
+    exportCount = 0;
+
+    for index = 0 to numFiles
+    {
+        file = files[index];
+
+        open = Sibelius.Open(file, True);
+        if (not open)
+        {
+            continue = Sibelius.YesNoMessageBox('File could not be opened:\n\n' & file & '\n\nContinue anyway?');
+            if (not continue)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            // NB: DO NOT CHANGE THIS EXTENSION PLEASE.
+            error = DoExport(file.Name & '.mei');
+            Sibelius.CloseWindow(False);
+            if (null = error)
+            {
+                exportCount = exportCount + 1;
+            }
+            else
+            {
+                if (not Sibelius.YesNoMessageBox(error & '\n\nContinue anyway?'))
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    Sibelius.DestroyProgressDialog();
+
+    Sibelius.MessageBox(exportCount & ' of ' & numFiles & ' files were exported.');
+
+    return true;
 }  //$end


### PR DESCRIPTION
Code for batch export from Sibelius and MusicXML was almost identical, but slowly diverged. Now it's unified again.

Additional improvements:
* Three MusicXML extensions are exported: *.xml, *.musicxml and *.mxl
* Hopefully more useful error message (also for non-batch export) if file could not be written
* Final message added
* Files are processed in a predictable order (alphabetical). The order of files when looping over a folder is otherwise rather random.

The progress dialog was removed because after a split second, it is overridden by the progress dialog looping over the bars of each file anyways.

Could someone please test on a Mac before merging?  Especially how the MusicXML export works.