### PR TITLE
add schema url for validation

### DIFF
--- a/lib/libmei4.plg
+++ b/lib/libmei4.plg
@@ -2045,7 +2045,8 @@ GetTail "(element) {
 
     _exportMeiDocument "(meidoc) {
         xdecl = '<?xml version=' & Chr(34) & '1.0' & Chr(34) & ' encoding=' & Chr(34) & 'UTF-16' & Chr(34) & ' ?>';
-        meiout = xdecl & convertDictToXml(meidoc[0], Chr(10));
+        schema = '\n<?xml-model href=' & Chr(34) & 'https://music-encoding.org/schema/4.0.1/mei-CMN.rng' & Chr(34) & ' type=' & Chr(34) & 'application/xml' & Chr(34) & ' schematypens=' & Chr(34) & 'http://relaxng.org/ns/structure/1.0' & Chr(34) & ' ?>';
+        meiout = xdecl & schema & convertDictToXml(meidoc[0], Chr(10));
 
         return meiout;
     }"

--- a/lib/libmei4.plg
+++ b/lib/libmei4.plg
@@ -2044,9 +2044,11 @@ GetTail "(element) {
 }"
 
     _exportMeiDocument "(meidoc) {
+        RNG_URL = 'https://music-encoding.org/schema/' & MeiVersion & '/mei-CMN.rng';
         xdecl = '<?xml version=' & Chr(34) & '1.0' & Chr(34) & ' encoding=' & Chr(34) & 'UTF-16' & Chr(34) & ' ?>';
-        schema = '\n<?xml-model href=' & Chr(34) & 'https://music-encoding.org/schema/4.0.1/mei-CMN.rng' & Chr(34) & ' type=' & Chr(34) & 'application/xml' & Chr(34) & ' schematypens=' & Chr(34) & 'http://relaxng.org/ns/structure/1.0' & Chr(34) & ' ?>';
-        meiout = xdecl & schema & convertDictToXml(meidoc[0], Chr(10));
+        schema = '\n<?xml-model href=' & Chr(34) & RNG_URL & Chr(34) & ' type=' & Chr(34) & 'application/xml' & Chr(34) & ' schematypens=' & Chr(34) & 'http://relaxng.org/ns/structure/1.0' & Chr(34) & ' ?>';
+        schematron = '\n<?xml-model href=' & Chr(34) & RNG_URL & Chr(34) & ' type=' & Chr(34) & 'application/xml' & Chr(34) & ' schematypens=' & Chr(34) & 'http://purl.oclc.org/dsdl/schematron' & Chr(34) & ' ?>';
+        meiout = xdecl & schema & schematron & convertDictToXml(meidoc[0], Chr(10));
 
         return meiout;
     }"

--- a/lib/libmei4.plg
+++ b/lib/libmei4.plg
@@ -24,7 +24,7 @@
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.';
     }"
 
-    
+
 Arpeg "() {
     CreateElement('arpeg', null);
 }"
@@ -1685,7 +1685,7 @@ SymbolTable "() {
     CreateElement('symbolTable', null);
 }"
 
-    
+
 Initialize "() {
         tree_doc = CreateSparseArray();
         flat_doc = CreateDictionary();


### PR DESCRIPTION
This PR adds a processing instruction to the generated MEI enabling validation against the published RNG, which makes manual testing much easier.

NB: This complicates working with customizations, but for official releases of sibmei this should be fine.