### PR TITLE
change technique text indicator from label to type

### DIFF
--- a/ExportHandlers.md
+++ b/ExportHandlers.md
@@ -61,7 +61,7 @@ For creating entries in the Handler mapping Dictionaries, the four registrations
 
 ```js
 api.RegisterTextHandlers('StyleId', 'ControlEventTemplateHandler', CreateDictionary(
-    'text.staff.technique', @Element('Dir', @Attrs('label', 'technique'),
+    'text.staff.technique', @Element('Dir', @Attrs('type', 'technique'),
         api.FormattedText
     )
 ));

--- a/src/TextHandler.mss
+++ b/src/TextHandler.mss
@@ -12,7 +12,7 @@ function InitTextHandlers() {
     RegisterTextHandlers('StyleId', 'ControlEventTemplateHandler', CreateDictionary(
         'text.staff.expression', @Element('Dynam', noAttributes, FormattedText),
         'text.staff.space.figuredbass', 'FiguredBassTextHandler',
-        'text.staff.technique', @Element('Dir', @Attrs('label', 'technique'), FormattedText),
+        'text.staff.technique', @Element('Dir', @Attrs('type', 'technique'), FormattedText),
         'text.system.page_aligned.composer', @Element('AnchoredText', @Attrs('func', 'composer', 'tstamp', ' '), FormattedText),
         'text.system.page_aligned.subtitle', @Element('AnchoredText', @Attrs('func', 'subtitle', 'tstamp', ' '), FormattedText),
         'text.system.page_aligned.title', @Element('AnchoredText', @Attrs('func', 'title', 'tstamp', ' '), FormattedText),

--- a/test/mocha/test-text.js
+++ b/test/mocha/test-text.js
@@ -82,7 +82,7 @@ describe("Text elements", function() {
     });
     it("exports technique text from measure 7", function() {
         const dir = xpath.evaluateXPath("//*:measure[@n='7']/*:dir", meiText);
-        assert.strictEqual(dir.getAttribute("label"), "technique");
+        assert.strictEqual(dir.getAttribute("type"), "technique");
     });
     it("exports color", function() {
         const dir = xpath.evaluateXPath("//*:measure[@n='7']/*:dir", meiText);


### PR DESCRIPTION
Small change to align text output to `dir` with other methods where we prefer `@type` for indicating the text type.