### PR TITLE
Fix crashes caused by invalid Sibelius.ActiveScore

### DIFF
--- a/src/ExportConverters.mss
+++ b/src/ExportConverters.mss
@@ -119,8 +119,6 @@ function ConvertDiatonicPitch (diatonic_pitch) {
 }  //$end
 
 function ConvertOffsetsToMEI (offset) {
-    //$module(ExportConverters.mss)
-
     /*
      This function will convert the 1/32 unit
      Sibelius offsets into the MEI virtual units as required by the
@@ -134,13 +132,10 @@ function ConvertOffsetsToMEI (offset) {
     MEI virtual unit (vu) is defined as half the distance between the vertical
     center point of a staff line and that of an adjacent staff line.
     */
-    retval = (offset / 16.0);
-    return retval & 'vu';
+    return (offset / 16.0) & 'vu';
 }  //$end
 
-function ConvertOffsetsToMillimeters (offset) {
-    //$module(ExportConverters.mss)
-
+function ConvertOffsetsToMillimeters (score, offset) {
     /*
      This function will convert the 1/32 unit
      Sibelius offsets into a millimeter measurement as required by the
@@ -156,24 +151,15 @@ function ConvertOffsetsToMillimeters (offset) {
     So a staff height of 7mm (default) gives us (7 / 128) = 0.05mm per Sibelius
     Unit.
     */
-    scr = Sibelius.ActiveScore;
-    staffheight = scr.StaffHeight;
-    factor = (staffheight / 128.0);
-    oset = factor * offset;
-    retval = oset & 'mm';
-    return retval;
+
+    return (score.StaffHeight / 128.0 * offset) & 'mm';
 }  //$end
 
-function ConvertUnitsToPoints (units) {
-    //$module(ExportConverters.mss)
-    scr = Sibelius.ActiveScore;
-    staffheight = scr.StaffHeight;
-
+function ConvertUnitsToPoints (score, units) {
     /*
         Points are 0.352778mm (a point is 1/72 of an inch * 25.4mm/in).
     */
-    retval = ((staffheight / 128.0) * units) / 0.352778;
-    return retval & 'pt';
+    return (score.StaffHeight / 128.0 * units / 0.352778) & 'pt';
 }  //$end
 
 function ConvertDuration (dur) {

--- a/src/Run.mss
+++ b/src/Run.mss
@@ -16,12 +16,9 @@ function Run() {
 }  //$end
 
 
-function GetExportFileName () {
-    // get the active score object
-    activeScore = Sibelius.ActiveScore;
-
-    if (Sibelius.FileExists(activeScore.FileName)) {
-        scoreFile = Sibelius.GetFile(activeScore.FileName);
+function GetExportFileName (score) {
+    if (Sibelius.FileExists(score.FileName)) {
+        scoreFile = Sibelius.GetFile(score.FileName);
         activeFileName = scoreFile.NameNoPath & '.mei';
         activePath = scoreFile.Path;
     } else {
@@ -29,7 +26,6 @@ function GetExportFileName () {
         activePath = Sibelius.GetDocumentsFolder();
     }
 
-    // Ask to the file to be saved somewhere
     filename = Sibelius.SelectFileToSave('Save as...', activeFileName, activePath, 'mei', 'TEXT', 'Music Encoding Initiative');
 
     return filename;
@@ -56,7 +52,7 @@ function DoExport (score, filename) {
 
     if (null = filename)
     {
-        filename = GetExportFileName();
+        filename = GetExportFileName(score);
         if (null = filename)
         {
             Sibelius.MessageBox(_ExportFileIsNull);
@@ -84,7 +80,7 @@ function DoExport (score, filename) {
     Self._property:warnings = CreateSparseArray();
 
     // Deal with the Progress GUI
-    progCount = Sibelius.ActiveScore.SystemStaff.BarCount;
+    progCount = score.SystemStaff.BarCount;
     fn = utils.ExtractFileName(filename);
     progressTitle = utils.Format(_InitialProgressTitle, fn);
     Sibelius.CreateProgressDialog(progressTitle, 0, progCount - 1);

--- a/src/Utilities.mss
+++ b/src/Utilities.mss
@@ -383,12 +383,16 @@ function AddControlEventAttributes (bobj, element) {
         libmei.AddAttribute(element, 'tstamp2', ConvertPositionWithDurationToTimestamp(bobj));
     }
 
-    if (bar.ParentStaff.StaffNum > 0)
+    staff = bar.ParentStaff;
+
+    if (staff.StaffNum > 0)
     {
         // Only add @staff if this is not attached to the SystemStaff
-        libmei.AddAttribute(element, 'staff', bar.ParentStaff.StaffNum);
+        libmei.AddAttribute(element, 'staff', staff.StaffNum);
         libmei.AddAttribute(element, 'layer', voicenum);
     }
+
+    score = staff.ParentScore;
 
     if (bobj.Type = 'Line')
     {
@@ -402,20 +406,20 @@ function AddControlEventAttributes (bobj, element) {
         // left hand offset
         if (bobj.Dx > 0)
         {
-            libmei.AddAttribute(element, 'startho', ConvertOffsetsToMillimeters(bobj.Dx));
+            libmei.AddAttribute(element, 'startho', ConvertOffsetsToMillimeters(score, bobj.Dx));
         }
         if (bobj.Dy > 0)
         {
-            libmei.AddAttribute(element, 'startvo', ConvertOffsetsToMillimeters(bobj.Dy));
+            libmei.AddAttribute(element, 'startvo', ConvertOffsetsToMillimeters(score, bobj.Dy));
         }
         // right hand offset
         if (bobj.RhDx > 0)
         {
-            libmei.AddAttribute(element, 'endho', ConvertOffsetsToMillimeters(bobj.Dx));
+            libmei.AddAttribute(element, 'endho', ConvertOffsetsToMillimeters(score, bobj.Dx));
         }
         if (bobj.RhDy > 0)
         {
-            libmei.AddAttribute(element, 'endvo', ConvertOffsetsToMillimeters(bobj.Dy));
+            libmei.AddAttribute(element, 'endvo', ConvertOffsetsToMillimeters(score, bobj.Dy));
         }
     }
     else
@@ -423,12 +427,12 @@ function AddControlEventAttributes (bobj, element) {
         // other types only have a left hand offset
         if (bobj.Dx > 0)
         {
-            libmei.AddAttribute(element, 'ho', ConvertOffsetsToMillimeters(bobj.Dx));
+            libmei.AddAttribute(element, 'ho', ConvertOffsetsToMillimeters(score, bobj.Dx));
         }
 
         if (bobj.Dy > 0)
         {
-            libmei.AddAttribute(element, 'vo', ConvertOffsetsToMillimeters(bobj.Dy));
+            libmei.AddAttribute(element, 'vo', ConvertOffsetsToMillimeters(score, bobj.Dy));
         }
     }
 

--- a/test/sib-test/TestExportConverters.mss
+++ b/test/sib-test/TestExportConverters.mss
@@ -29,7 +29,7 @@ function TestDiatonicPitchConverter(assert, plugin) {
 function TestOffsetConverter(assert, plugin) {
     //$module(TestNoteNameConverter)
     EnsureActiveScoreExists();
-    output = sibmei.ConvertOffsetsToMillimeters(100);
+    output = sibmei.ConvertOffsetsToMillimeters(Sibelius.ActiveScore, 100);
     assert.Equal(output, '5.4688mm', 'Offset of 100 1/32nds of a space is 5mm');
 }  //$end
 


### PR DESCRIPTION
@rettinghaus, does this fix #246?

I also streamlined the functions a bit.  Intermediate assignments are not necessary.  I believe those assignments were originally used because Sibelius can indeed crash sometimes if values are not assigned to variables, but this basically only happens for TreeNodes, which frequently get garbage collected prematurely if not assigned to persistent variables.

An interesting observation I'd like to share:  This function:

```javascript
function ConvertOffsetsToMillimeters (score, offset) {
    return (score.StaffHeight / 128.0 * offset) & 'mm';
}  //$end
```
... has about the same performance as the old function using `Sibelius.ActiveScore`, but both are more than 100x slower than this function:
```javascript
function ConvertOffsetsToMillimeters (staffHeight, offset) {
    return (staffHeight / 128.0 * offset) & 'mm';
}  //$end
```
... or this function:
```javascript
function ConvertOffsetsToMillimeters (this, offset) {
    return (this.staffHeight / 128.0 * offset) & 'mm';
}  //$end
```
So passing around or retreiving the score object seems to have a tremendous overhead.  Even if the passed score is not used at all, this causes the 100x slowdown, like here:
```javascript
function ConvertOffsetsToMillimeters (staffHeight, score, offset) {
    return (staffHeight / 128.0 * offset) & 'mm';
}  //$end
```
Other objects don't have such an impact. E.g. passing the SystemStaff only has a marginal impact:
```javascript
function ConvertOffsetsToMillimeters (staffHeight, systemStaff, offset) {
    return (staffHeight / 128.0 * offset) & 'mm';
}  //$end
```
If however the system staff is used to access the score, the 100x slowdown is there again:
```javascript
function ConvertOffsetsToMillimeters (systemStaff, offset) {
    return (systemStaff.ParentScore.StaffHeight / 128.0 * offset) & 'mm';
}  //$end
```
It might therefore be a good idea to cache some things. This could be done like:
```javascript
Self._property:StaffHeight = score.StaffHeight;
```
Opinions welcome.