### PR TITLE
fix: MEI 4 doesn't allow color on text elements

### DIFF
--- a/src/ExportGenerators.mss
+++ b/src/ExportGenerators.mss
@@ -1148,6 +1148,11 @@ function GenerateControlEvent (bobj, element) {
 
 
 function GenerateModifier (bobj, element) {
+    if (bobj.Color != 0)
+    {
+        libmei.AddAttribute(element, 'color', ConvertColor(bobj));
+    }
+
     nobj = GetNoteObjectAtPosition(bobj, 'Closest');
 
     if (nobj != null)

--- a/src/Utilities.mss
+++ b/src/Utilities.mss
@@ -432,11 +432,13 @@ function AddControlEventAttributes (bobj, element) {
         }
     }
 
-    if (bobj.Color != 0)
+    if (bobj.Type != 'Text')
     {
-        libmei.AddAttribute(element, 'color', ConvertColor(bobj));
+        if (bobj.Color != 0)
+        {
+            libmei.AddAttribute(element, 'color', ConvertColor(bobj));
+        }
     }
-
 
     return element;
 


### PR DESCRIPTION
This is a small fix for textual control elements like `dir` and `dynam`, which are not member of `att.color` in MEI 4. 

Export for color of articulations has been added.
