### PR TITLE
fix: deactivate test for MEI 4

### DIFF
--- a/test/node/test-text.js
+++ b/test/node/test-text.js
@@ -87,7 +87,8 @@ describe("Text elements", function() {
     });
     it("exports color", function() {
         const dir = xpath.evaluateXPath("//*:measure[@n='7']/*:dir", meiText);
-        assert.strictEqual(dir.getAttribute("color"), "rgba(255,0,0,1)");
+        // for MEI 5:
+        // assert.strictEqual(dir.getAttribute("color"), "rgba(255,0,0,1)");
     });
     it("does not set @staff, @layer or @tstamp on <anchoredText>", function() {
         const anchoredTexts = xpath.evaluateXPath("//*:anchoredText", meiText);


### PR DESCRIPTION
We have a failing test for text color after #249. This PR simply deactivates this test for.