### PR TITLE
Last important fixes for MEI 4 

### DIFF
--- a/src/ExportConverters.mss
+++ b/src/ExportConverters.mss
@@ -767,6 +767,13 @@ function ConvertTimeStamp (time) {
     // Converts a timestamp in milliseconds to an
     // isotime (hh:mm:ss.s) suitable for use in @tstamp.real
 
+    if (time < 0)
+    {
+        // Negative times can occur when Sibelius does not know when an event
+        // is played. In that case, don't write a time.
+        return ' ';
+    }
+
     mins = utils.GetMinutesFromTime(time);
 
     secs = time % 60000.0 / 1000.0;

--- a/src/Initialize.mss
+++ b/src/Initialize.mss
@@ -59,7 +59,7 @@ function InitGlobals (extensions) {
     BarlineAttributes[SpecialBarlineInvisible] = @Attrs('right', 'invis');
     BarlineAttributes[SpecialBarlineNormal] = @Attrs('right', 'single');
     BarlineAttributes[SpecialBarlineDotted] = @Attrs('right', 'dotted');
-    BarlineAttributes[SpecialBarlineThick] = @Attrs('right', 'heavy');
+    // BarlineAttributes[SpecialBarlineThick] = @Attrs('right', 'heavy');
     BarlineAttributes[SpecialBarlineBetweenStaves] = @Attrs('bar.method', 'mensur');
     BarlineAttributes[SpecialBarlineTick] = @Attrs('bar.method', 'takt');
     BarlineAttributes[SpecialBarlineShort] = @Attrs('bar.len', '4', 'bar.place', '2');

--- a/src/LyricHandler.mss
+++ b/src/LyricHandler.mss
@@ -227,10 +227,6 @@ function CreateSylChild (parent, template, lyricItem, sylText) {
     // inserted text.
     lyricItem._property:currentSyllable = sylText;
     sylElement = MeiFactory(template, lyricItem);
-    if (lyricItem.Color != 0)
-    {
-        libmei.AddAttribute(sylElement, 'color', ConvertColor(lyricItem));
-    }
     libmei.AddChild(parent, sylElement);
     return sylElement;
 } //$end


### PR DESCRIPTION
Three last small fixes to make exported MEI files vaild:

* do not try to export negative time (leads to bad formatted isotime)
* do not color syl elements
* do not (yet) export single heavy bar lines

