### PR TITLE
Prepare bugfix release 5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sibmei",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sibmei",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "devDependencies": {
         "chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sibmei",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "MEI export plugin for Avid Sibelius",
   "sibmei": {
     "meiVersion": "5.1"
@@ -24,11 +24,5 @@
     "chokidar": "^5.0.0",
     "fontoxpath": "^3.34.0",
     "slimdom-sax-parser": "^1.5.3"
-  },
-  "resolutions": {
-    "graceful-fs": "^4.2.10"
-  },
-  "overrides": {
-    "graceful-fs": "^4.2.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,23 +4,18 @@
 
 chokidar@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-5.0.0.tgz#949c126a9238a80792be9a0265934f098af369a5"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz"
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
 
 fontoxpath@^3.34.0:
   version "3.34.0"
-  resolved "https://registry.yarnpkg.com/fontoxpath/-/fontoxpath-3.34.0.tgz#a17c8c97e82bb7f5c166b0e003669dc943ddd907"
+  resolved "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.34.0.tgz"
   integrity sha512-7FgBQRohn4WR/2eVdYqZtKBFZkJNaiP4kGdfqS6bAg465og05ixGA2OgfMdxsO1mnX67+64JX/8JKclVqS+bzA==
   dependencies:
     prsc "4.0.0"
     xspattern "^3.1.0"
-
-graceful-fs@^4.2.10:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
-  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 prsc@4.0.0:
   version "4.0.0"
@@ -29,7 +24,7 @@ prsc@4.0.0:
 
 readdirp@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-5.0.0.tgz#fbf1f71a727891d685bb1786f9ba74084f6e2f91"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz"
   integrity sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==
 
 saxes@6.0.0:


### PR DESCRIPTION
While editing `package.json`, I also removed the `graceful-fs` resolutions/overrides, which I believe are leftovers from the gulp and mocha times with lots of meta dependencies. The currently used packages do not depend on `graceful-fs`.