### PR TITLE
Add Sibmei version to test extension titles

### DIFF
--- a/test/extension_specific_schema.plg
+++ b/test/extension_specific_schema.plg
@@ -3,7 +3,7 @@
   CustomSchemaLocation "https://example.com/schema/custom.rng"
 
   Initialize "() {
-    AddToPluginsMenu('Sibmei extension schema test', 'Run');
+    AddToPluginsMenu('Sibmei ' & PluginVersion & ' extension schema test', 'Run');
   }"
 
   InitSibmeiExtension "(api) {

--- a/test/extension_test.plg
+++ b/test/extension_test.plg
@@ -4,7 +4,7 @@
   Smiley "☺"
 
   Initialize "() {
-    AddToPluginsMenu('Sibmei extension test', 'Run');
+    AddToPluginsMenu('Sibmei ' & PluginVersion & ' extension test', 'Run');
   }"
 
   Run "() {

--- a/test/extension_test_omitting_schema.plg
+++ b/test/extension_test_omitting_schema.plg
@@ -3,7 +3,7 @@
   CustomSchemaLocation "noSchema"
 
   Initialize "() {
-    AddToPluginsMenu('Sibmei extension with empty schemas test', 'Run');
+    AddToPluginsMenu('Sibmei ' & PluginVersion & ' extension with empty schemas test', 'Run');
   }"
 
   InitSibmeiExtension "(api) {


### PR DESCRIPTION
We had the situation that extension test plugins (e.g. `sibmei4_extension_test.plg` and `sibmei5_extension_test.plg`) registered the same plugin title. This leads to multiple indistinguishable entries in the extension choice dialog.
<img width="246" height="80" alt="image" src="https://github.com/user-attachments/assets/b6621bfc-a731-492c-b566-a0f2bae92f71" />
This PR fixes this. The new extensions have the version in their name.
<img width="176" height="53" alt="image" src="https://github.com/user-attachments/assets/7f83bdb5-ec2d-4b35-b7ac-1b2974226bed" />
