### PR TITLE
Add `@tstamp.real` to all control events

### DIFF
--- a/src/ExportConverters.mss
+++ b/src/ExportConverters.mss
@@ -601,37 +601,24 @@ function ConvertTimeStamp (time) {
         return ' ';
     }
 
-    mins = utils.GetMinutesFromTime(time);
-
     secs = time % 60000.0 / 1000.0;
-    // We need to ensure that values always have two digits
-    if (secs < 10.0)
+    mins = time % 3600000 / 60000;
+    hours = time / 3600000;
+
+    if (secs < 10)
     {
         secs = '0' & secs;
     }
-
-    hours = 0;
-    if (mins > 60)
+    if (mins < 10)
     {
-        rem = mins % 60;
-        hours = (mins - rem) / 60;
-        mins = rem;
-
-        // Only if mins > 60 we need to make sure, that there are two digits
-        if (mins < 10)
-        {
-            mins = '0' & mins;
-        }
+        mins = '0' & mins;
     }
-
-    // In the case of a very long score, we need to make sure, that there are always two digits
     if (hours < 10)
     {
         hours = '0' & hours;
     }
 
-    isodate = utils.Format('%s:%s:%s', hours, mins, secs);
-    return isodate;
+    return hours & ':' & mins & ':' & secs;
 }  //$end
 
 function ConvertFermataForm (bobj) {

--- a/src/Utilities.mss
+++ b/src/Utilities.mss
@@ -366,6 +366,7 @@ function AddControlEventAttributes (bobj, element) {
         // Some templates might set `@tstamp` explicitly, especially to prevent
         // `@tstamp` from being output for elements that don't allow it.
         AddAttribute(element, 'tstamp', ConvertPositionToTimestamp(bobj.Position, bar));
+        AddAttribute(element, 'tstamp.real', ConvertTimeStamp(bobj.Time));
     }
 
     start_obj = GetNoteObjectAtPosition(bobj, 'PreciseMatch', 'Position');


### PR DESCRIPTION
This is useful for playback oriented applications (when does the dynamic or tempo change occur?) and it's an easier alternative to `@tstamp` when analyzing the music for the order of events and alignment of elements.

I found that `ConvertTimeStamp()` was buggy and returned `00:60:00` for one hour. I fixed that and also made it about 15-20 times faster.

I added it in the `if` block that tests whether `@tstamp` should be written because `@tstamp.real` is available at all the elements that support `@tstamp` (plus some more).